### PR TITLE
draft/add-injective

### DIFF
--- a/pages/api/check.ts
+++ b/pages/api/check.ts
@@ -124,9 +124,9 @@ const AirdropRegistry = {
     "contract": 'juno1tqv6032656485dtvs3p65t4ze6yf4f6rmej8yc3mj7xqem60elesh3en96'
   },
   "injective": {
-    "url": 'https://gist.githubusercontent.com/LeTurt333/8e4693159e770820c2cf60b15f7c830f/raw/971ffb4b33cdf5a2632ee1da858d64bf1a50d459/mock_inj_randdrop.json',
+    "url": 'https://gist.githubusercontent.com/kaisbaccour/c26ede9d4219896bc03fb0fdfce310a3/raw/52320781cd31cb832b79883195ad0535af95b273/injective-randdrop.json',
     //"url": 'https://gist.githubusercontent.com/kaisbaccour/c26ede9d4219896bc03fb0fdfce310a3/raw/fa0825eb75607afad08ffb0fdead8567795150ad/injective-randdrop.json',
-    "contract": 'inj1076whk0ngxg64c950wwcvj0xpjg0mhw6xellz7'
+    "contract": 'inj17ryua25yypx7q58g3wxjwquvaz2vs8wmula59u'
   },
   "stargaze": {
     "url": 'https://gist.githubusercontent.com/kaisbaccour/ac8002e0329b4f54407e702c5dc4aa47/raw/1c8a75bdabf3dc04f77ed0d2c1cefedbba4fa060/stargaze-randdrop.json',

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -17,7 +17,7 @@ import { ChainType, CheckResponse } from './api/check';
 
 // Config for live / not live randdrop chains
 export const AirdropLiveStatus: { [K in ChainType]: boolean } = {
-  "injective": false,
+  "injective": true,
   "juno": true,
   "uni": false,
   "stargaze": true,

--- a/services/chainConfig.ts
+++ b/services/chainConfig.ts
@@ -21,7 +21,7 @@ export const getChainConfig = (chain: ChainType) => {
     }
     case "injective": {
       //testnet
-      return injective888ChainConfig;
+      return injectiveChainConfig;
       //mainnet
       //return injectiveChainConfig;
     }


### PR DESCRIPTION
querying the injective contract works fine (I can see if I won the randdrop or not), but when trying to participate, trying  to prepare, sign and broadcast the transaction fails.
Error: **Unsupported type injective.types.v1beta1.EthAccount**
The way to solve it is to use **@injectivelabs/sdk-ts** instead of **@cosmjs/stargate**
These docs provide how to use the injective library https://docs.ts.injective.network/transactions/transactions-cosmos
And here's an example https://github.com/InjectiveLabs/injective-ts/blob/862e7c30d96120947b056abffbd01b4f378984a1/packages/wallet-ts/src/broadcaster/MsgBroadcaster.ts#L301-L365